### PR TITLE
Update requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 requests
 argparse
-urllib
 cryptocode


### PR DESCRIPTION
urllib is not installed through pip, it is part of the standard library, so you can just do import urllib without installation.