### PR TITLE
Update CVE-2022-22965_exploit.py

### DIFF
--- a/CVE-2022-22965_exploit.py
+++ b/CVE-2022-22965_exploit.py
@@ -3,6 +3,7 @@ import os
 import re
 import sys
 import time
+import urllib
 from random import choice
 from string import ascii_letters
 from urllib.parse import urljoin, urlparse


### PR DESCRIPTION
urllib is not installed through pip, it is part of the standard library, so you can just do import urllib without installation.